### PR TITLE
Typo in pytest.ini 

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
-addopts = --json-report
+adopts = --json-report
+


### PR DESCRIPTION
original code made it impossible to run local tests. had this error: 

pytest: error: unrecognized arguments: --json-report